### PR TITLE
Correctly set node attributes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,9 @@ exports.createParser = function (callback) {
             value = elementAttrs || '';
 
             if (node instanceof Array) {
+                if (typeof value === 'object') {
+                    internals.setAttributes(node[node.length-1], value);
+                }
                 node = tree.pop();      // Return to parent
             }
             else if (node[name] instanceof Array) {
@@ -103,11 +106,7 @@ exports.createParser = function (callback) {
                 node[name] = value;
             }
             else if (typeof value === 'object') {
-                var keys = Object.keys(value);
-                for (var i = 0, il = keys.length; i < il; ++i) {
-                    var key = keys[i];
-                    node[name][key] = value[key];
-                }
+                internals.setAttributes(node[name], value);
             }
         }
     });
@@ -141,3 +140,11 @@ internals.cleanText = function (text) {
 
     return text.replace(/(^\s+|\s+$)/g, '');
 };
+
+internals.setAttributes = function (node, value) {
+  var keys = Object.keys(value);
+  for (var i = 0, il = keys.length; i < il; ++i) {
+      var key = keys[i];
+      node[key] = value[key];
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,7 @@ describe('createParser()', function () {
                 property: 'a',
                 child: [
                 {
+                    id: '1',
                     name: '2',
                     property: 'a',
                     child: [
@@ -43,6 +44,7 @@ describe('createParser()', function () {
                     ]
                 },
                 {
+                    id: '2',
                     name: '5'
                 }
                 ],

--- a/test/test1.xml
+++ b/test/test1.xml
@@ -2,7 +2,7 @@
 <item>
   <name>1</name>
   <property>a</property>
-  <child>
+  <child id='1'>
     <name>2</name>
     <property>a</property>
     <child>
@@ -13,7 +13,7 @@
       <name>4</name>
     </child>
   </child>
-  <child>
+  <child id='2'>
     <name>5</name>
   </child>
   <goblins>


### PR DESCRIPTION
If the current node is part of an array, like when there is multiple
children with the same name, only the first one had its attributes set,
due to https://github.com/hapijs/faketoe/blob/master/lib/index.js#L96.

Now, if it's in an array, the last item of the array is given the
attributes.

I've updated the test and the fixture to reflect that.

Close #24